### PR TITLE
Feature mongo async

### DIFF
--- a/src/simple-todos/step02/server/main.js
+++ b/src/simple-todos/step02/server/main.js
@@ -1,10 +1,11 @@
 import { Meteor } from 'meteor/meteor';
 import { TasksCollection } from '/imports/api/TasksCollection';
 
-const insertTask = taskText => TasksCollection.insert({ text: taskText });
+const insertTask = async (taskText) =>
+  await TasksCollection.insertAsync({ text: taskText });
 
-Meteor.startup(() => {
-  if (TasksCollection.find().count() === 0) {
+Meteor.startup(async () => {
+  if (TasksCollection.find().countAsync() === 0) {
     [
       'First Task',
       'Second Task',

--- a/src/simple-todos/step03/imports/ui/App.js
+++ b/src/simple-todos/step03/imports/ui/App.js
@@ -9,7 +9,7 @@ Template.mainContainer.helpers({
 });
 
 Template.form.events({
-  'submit .task-form'(event) {
+ async 'submit .task-form'(event) {
     // Prevent default browser form submit
     event.preventDefault();
 
@@ -18,7 +18,7 @@ Template.form.events({
     const text = target.text.value;
 
     // Insert a task into the collection
-    TasksCollection.insert({
+    await TasksCollection.insertAsync({
       text,
       createdAt: new Date(), // current time
     });

--- a/src/simple-todos/step03/server/main.js
+++ b/src/simple-todos/step03/server/main.js
@@ -1,10 +1,11 @@
 import { Meteor } from 'meteor/meteor';
 import { TasksCollection } from '/imports/api/TasksCollection';
 
-const insertTask = taskText => TasksCollection.insert({ text: taskText });
+const insertTask = async (taskText) =>
+  await TasksCollection.insertAsync({ text: taskText });
 
-Meteor.startup(() => {
-  if (TasksCollection.find().count() === 0) {
+Meteor.startup(async () => {
+  if (TasksCollection.find().countAsync() === 0) {
     [
       'First Task',
       'Second Task',

--- a/src/simple-todos/step04/imports/ui/App.js
+++ b/src/simple-todos/step04/imports/ui/App.js
@@ -10,7 +10,7 @@ Template.mainContainer.helpers({
 });
 
 Template.form.events({
-  'submit .task-form'(event) {
+  async 'submit .task-form'(event) {
     // Prevent default browser form submit
     event.preventDefault();
 
@@ -19,7 +19,7 @@ Template.form.events({
     const text = target.text.value;
 
     // Insert a task into the collection
-    TasksCollection.insert({
+    await TasksCollection.insertAsync({
       text,
       createdAt: new Date(), // current time
     });

--- a/src/simple-todos/step04/imports/ui/Task.js
+++ b/src/simple-todos/step04/imports/ui/Task.js
@@ -5,13 +5,13 @@ import { TasksCollection } from '../api/TasksCollection';
 import './Task.html';
 
 Template.task.events({
-  'click .toggle-checked'() {
+  async 'click .toggle-checked'() {
     // Set the checked property to the opposite of its current value
-    TasksCollection.update(this._id, {
+    await TasksCollection.updateAsync(this._id, {
       $set: { isChecked: !this.isChecked },
     });
   },
-  'click .delete'() {
-    TasksCollection.remove(this._id);
+  async 'click .delete'() {
+    await TasksCollection.removeAsync(this._id);
   },
 });

--- a/src/simple-todos/step04/server/main.js
+++ b/src/simple-todos/step04/server/main.js
@@ -1,10 +1,11 @@
 import { Meteor } from 'meteor/meteor';
 import { TasksCollection } from '/imports/api/TasksCollection';
 
-const insertTask = taskText => TasksCollection.insert({ text: taskText });
+const insertTask = async (taskText) =>
+  await TasksCollection.insertAsync({ text: taskText });
 
-Meteor.startup(() => {
-  if (TasksCollection.find().count() === 0) {
+Meteor.startup(async () => {
+  if (TasksCollection.find().countAsync() === 0) {
     [
       'First Task',
       'Second Task',

--- a/src/simple-todos/step05/imports/ui/App.js
+++ b/src/simple-todos/step05/imports/ui/App.js
@@ -10,7 +10,7 @@ Template.mainContainer.helpers({
 });
 
 Template.form.events({
-  'submit .task-form'(event) {
+  async 'submit .task-form'(event) {
     // Prevent default browser form submit
     event.preventDefault();
 
@@ -19,7 +19,7 @@ Template.form.events({
     const text = target.text.value;
 
     // Insert a task into the collection
-    TasksCollection.insert({
+    await TasksCollection.insertAsync({
       text,
       createdAt: new Date(), // current time
     });

--- a/src/simple-todos/step05/imports/ui/Task.js
+++ b/src/simple-todos/step05/imports/ui/Task.js
@@ -5,13 +5,13 @@ import { TasksCollection } from '../api/TasksCollection';
 import './Task.html';
 
 Template.task.events({
-  'click .toggle-checked'() {
+  async 'click .toggle-checked'() {
     // Set the checked property to the opposite of its current value
-    TasksCollection.update(this._id, {
+    await TasksCollection.updateAsync(this._id, {
       $set: { isChecked: !this.isChecked },
     });
   },
-  'click .delete'() {
-    TasksCollection.remove(this._id);
+  async 'click .delete'() {
+    await TasksCollection.removeAsync(this._id);
   },
 });

--- a/src/simple-todos/step05/server/main.js
+++ b/src/simple-todos/step05/server/main.js
@@ -1,10 +1,11 @@
 import { Meteor } from 'meteor/meteor';
 import { TasksCollection } from '/imports/api/TasksCollection';
 
-const insertTask = taskText => TasksCollection.insert({ text: taskText });
+const insertTask = async (taskText) =>
+  await TasksCollection.insertAsync({ text: taskText });
 
-Meteor.startup(() => {
-  if (TasksCollection.find().count() === 0) {
+Meteor.startup(async () => {
+  if (TasksCollection.find().countAsync() === 0) {
     [
       'First Task',
       'Second Task',

--- a/src/simple-todos/step06/imports/ui/App.js
+++ b/src/simple-todos/step06/imports/ui/App.js
@@ -18,29 +18,29 @@ Template.mainContainer.events({
 });
 
 Template.mainContainer.helpers({
-  tasks() {
+  async tasks() {
     const instance = Template.instance();
     const hideCompleted = instance.state.get(HIDE_COMPLETED_STRING);
 
     const hideCompletedFilter = { isChecked: { $ne: true } };
 
-    return TasksCollection.find(hideCompleted ? hideCompletedFilter : {}, {
+    return await TasksCollection.find(hideCompleted ? hideCompletedFilter : {}, {
       sort: { createdAt: -1 },
-    }).fetch();
+    }).fetchAsync();
   },
   hideCompleted() {
     return Template.instance().state.get(HIDE_COMPLETED_STRING);
   },
-  incompleteCount() {
-    const incompleteTasksCount = TasksCollection.find({
+  async incompleteCount() {
+    const incompleteTasksCount = await TasksCollection.find({
       isChecked: { $ne: true },
-    }).count();
+    }).countAsync();
     return incompleteTasksCount ? `(${incompleteTasksCount})` : '';
   },
 });
 
 Template.form.events({
-  'submit .task-form'(event) {
+  async 'submit .task-form'(event) {
     // Prevent default browser form submit
     event.preventDefault();
 
@@ -49,7 +49,7 @@ Template.form.events({
     const text = target.text.value;
 
     // Insert a task into the collection
-    TasksCollection.insert({
+    await TasksCollection.insertAsync({
       text,
       createdAt: new Date(), // current time
     });

--- a/src/simple-todos/step06/imports/ui/Task.js
+++ b/src/simple-todos/step06/imports/ui/Task.js
@@ -5,13 +5,13 @@ import { TasksCollection } from '../api/TasksCollection';
 import './Task.html';
 
 Template.task.events({
-  'click .toggle-checked'() {
+  async 'click .toggle-checked'() {
     // Set the checked property to the opposite of its current value
-    TasksCollection.update(this._id, {
+    await TasksCollection.updateAsync(this._id, {
       $set: { isChecked: !this.isChecked },
     });
   },
-  'click .delete'() {
-    TasksCollection.remove(this._id);
+  async 'click .delete'() {
+    await TasksCollection.removeAsync(this._id);
   },
 });

--- a/src/simple-todos/step06/server/main.js
+++ b/src/simple-todos/step06/server/main.js
@@ -1,10 +1,11 @@
 import { Meteor } from 'meteor/meteor';
 import { TasksCollection } from '/imports/api/TasksCollection';
 
-const insertTask = taskText => TasksCollection.insert({ text: taskText });
+const insertTask = async (taskText) =>
+  await TasksCollection.insertAsync({ text: taskText });
 
-Meteor.startup(() => {
-  if (TasksCollection.find().count() === 0) {
+Meteor.startup(async () => {
+  if (await TasksCollection.find().countAsync() === 0) {
     [
       'First Task',
       'Second Task',

--- a/src/simple-todos/step07/imports/ui/App.js
+++ b/src/simple-todos/step07/imports/ui/App.js
@@ -38,7 +38,7 @@ Template.mainContainer.events({
 });
 
 Template.mainContainer.helpers({
-  tasks() {
+  async tasks() {
     const instance = Template.instance();
     const hideCompleted = instance.state.get(HIDE_COMPLETED_STRING);
 
@@ -48,26 +48,26 @@ Template.mainContainer.helpers({
       return [];
     }
 
-    return TasksCollection.find(
+    return await TasksCollection.find(
       hideCompleted ? pendingOnlyFilter : userFilter,
       {
         sort: { createdAt: -1 },
       }
-    ).fetch();
+    ).fetchAsync();
   },
   hideCompleted() {
     return Template.instance().state.get(HIDE_COMPLETED_STRING);
   },
-  incompleteCount() {
+  async incompleteCount() {
     if (!isUserLogged()) {
       return '';
     }
 
     const { pendingOnlyFilter } = getTasksFilter();
 
-    const incompleteTasksCount = TasksCollection.find(
+    const incompleteTasksCount = await TasksCollection.find(
       pendingOnlyFilter
-    ).count();
+    ).countAsync();
     return incompleteTasksCount ? `(${incompleteTasksCount})` : '';
   },
   isUserLogged() {
@@ -79,7 +79,7 @@ Template.mainContainer.helpers({
 });
 
 Template.form.events({
-  'submit .task-form'(event) {
+  async 'submit .task-form'(event) {
     // Prevent default browser form submit
     event.preventDefault();
 
@@ -88,7 +88,7 @@ Template.form.events({
     const text = target.text.value;
 
     // Insert a task into the collection
-    TasksCollection.insert({
+    await TasksCollection.insertAsync({
       text,
       userId: getUser()._id,
       createdAt: new Date(), // current time

--- a/src/simple-todos/step07/imports/ui/Task.js
+++ b/src/simple-todos/step07/imports/ui/Task.js
@@ -5,13 +5,13 @@ import { TasksCollection } from '../api/TasksCollection';
 import './Task.html';
 
 Template.task.events({
-  'click .toggle-checked'() {
+  async 'click .toggle-checked'() {
     // Set the checked property to the opposite of its current value
-    TasksCollection.update(this._id, {
+    await TasksCollection.updateAsync(this._id, {
       $set: { isChecked: !this.isChecked },
     });
   },
-  'click .delete'() {
-    TasksCollection.remove(this._id);
+  async 'click .delete'() {
+    await TasksCollection.removeAsync(this._id);
   },
 });

--- a/src/simple-todos/step07/server/main.js
+++ b/src/simple-todos/step07/server/main.js
@@ -3,7 +3,7 @@ import { Accounts } from 'meteor/accounts-base';
 import { TasksCollection } from '/imports/api/TasksCollection';
 
 const insertTask = async (taskText, user) =>
-  TasksCollection.insertAsync({
+  await TasksCollection.insertAsync({
     text: taskText,
     userId: user._id,
     createdAt: new Date(),

--- a/src/simple-todos/step07/server/main.js
+++ b/src/simple-todos/step07/server/main.js
@@ -2,8 +2,8 @@ import { Meteor } from 'meteor/meteor';
 import { Accounts } from 'meteor/accounts-base';
 import { TasksCollection } from '/imports/api/TasksCollection';
 
-const insertTask = (taskText, user) =>
-  TasksCollection.insert({
+const insertTask = async (taskText, user) =>
+  TasksCollection.insertAsync({
     text: taskText,
     userId: user._id,
     createdAt: new Date(),
@@ -12,7 +12,7 @@ const insertTask = (taskText, user) =>
 const SEED_USERNAME = 'meteorite';
 const SEED_PASSWORD = 'password';
 
-Meteor.startup(() => {
+Meteor.startup(async () => {
   if (!Accounts.findUserByUsername(SEED_USERNAME)) {
     Accounts.createUser({
       username: SEED_USERNAME,
@@ -22,7 +22,7 @@ Meteor.startup(() => {
 
   const user = Accounts.findUserByUsername(SEED_USERNAME);
 
-  if (TasksCollection.find().count() === 0) {
+  if (await TasksCollection.find().countAsync() === 0) {
     [
       'First Task',
       'Second Task',

--- a/src/simple-todos/step08/imports/api/tasksMethods.js
+++ b/src/simple-todos/step08/imports/api/tasksMethods.js
@@ -3,31 +3,31 @@ import { check } from 'meteor/check';
 import { TasksCollection } from '../db/TasksCollection';
 
 Meteor.methods({
-  'tasks.insert'(text) {
+  async 'tasks.insert'(text) {
     check(text, String);
 
     if (!this.userId) {
       throw new Meteor.Error('Not authorized.');
     }
 
-    TasksCollection.insert({
+    await TasksCollection.insertAsync({
       text,
       createdAt: new Date(),
       userId: this.userId,
     });
   },
 
-  'tasks.remove'(taskId) {
+  async 'tasks.remove'(taskId) {
     check(taskId, String);
 
     if (!this.userId) {
       throw new Meteor.Error('Not authorized.');
     }
 
-    TasksCollection.remove(taskId);
+    await TasksCollection.removeAsync(taskId);
   },
 
-  'tasks.setIsChecked'(taskId, isChecked) {
+  async 'tasks.setIsChecked'(taskId, isChecked) {
     check(taskId, String);
     check(isChecked, Boolean);
 
@@ -35,7 +35,7 @@ Meteor.methods({
       throw new Meteor.Error('Not authorized.');
     }
 
-    TasksCollection.update(taskId, {
+    await TasksCollection.updateAsync(taskId, {
       $set: {
         isChecked,
       },

--- a/src/simple-todos/step08/imports/ui/App.js
+++ b/src/simple-todos/step08/imports/ui/App.js
@@ -38,7 +38,7 @@ Template.mainContainer.events({
 });
 
 Template.mainContainer.helpers({
-  tasks() {
+  async tasks() {
     const instance = Template.instance();
     const hideCompleted = instance.state.get(HIDE_COMPLETED_STRING);
 
@@ -48,26 +48,26 @@ Template.mainContainer.helpers({
       return [];
     }
 
-    return TasksCollection.find(
+    return await TasksCollection.find(
       hideCompleted ? pendingOnlyFilter : userFilter,
       {
         sort: { createdAt: -1 },
       }
-    ).fetch();
+    ).fetchAsync();
   },
   hideCompleted() {
     return Template.instance().state.get(HIDE_COMPLETED_STRING);
   },
-  incompleteCount() {
+  async incompleteCount() {
     if (!isUserLogged()) {
       return '';
     }
 
     const { pendingOnlyFilter } = getTasksFilter();
 
-    const incompleteTasksCount = TasksCollection.find(
+    const incompleteTasksCount = await TasksCollection.find(
       pendingOnlyFilter
-    ).count();
+    ).countAsync();
     return incompleteTasksCount ? `(${incompleteTasksCount})` : '';
   },
   isUserLogged() {

--- a/src/simple-todos/step08/server/main.js
+++ b/src/simple-todos/step08/server/main.js
@@ -4,7 +4,7 @@ import { TasksCollection } from '/imports/db/TasksCollection';
 import '/imports/api/tasksMethods';
 
 const insertTask = async (taskText, user) =>
-  TasksCollection.insertAsync({
+  await TasksCollection.insertAsync({
     text: taskText,
     userId: user._id,
     createdAt: new Date(),

--- a/src/simple-todos/step08/server/main.js
+++ b/src/simple-todos/step08/server/main.js
@@ -3,8 +3,8 @@ import { Accounts } from 'meteor/accounts-base';
 import { TasksCollection } from '/imports/db/TasksCollection';
 import '/imports/api/tasksMethods';
 
-const insertTask = (taskText, user) =>
-  TasksCollection.insert({
+const insertTask = async (taskText, user) =>
+  TasksCollection.insertAsync({
     text: taskText,
     userId: user._id,
     createdAt: new Date(),
@@ -13,7 +13,7 @@ const insertTask = (taskText, user) =>
 const SEED_USERNAME = 'meteorite';
 const SEED_PASSWORD = 'password';
 
-Meteor.startup(() => {
+Meteor.startup(async () => {
   if (!Accounts.findUserByUsername(SEED_USERNAME)) {
     Accounts.createUser({
       username: SEED_USERNAME,
@@ -23,7 +23,7 @@ Meteor.startup(() => {
 
   const user = Accounts.findUserByUsername(SEED_USERNAME);
 
-  if (TasksCollection.find().count() === 0) {
+  if (await TasksCollection.find().countAsync() === 0) {
     [
       'First Task',
       'Second Task',

--- a/src/simple-todos/step09/imports/api/tasksMethods.js
+++ b/src/simple-todos/step09/imports/api/tasksMethods.js
@@ -3,37 +3,37 @@ import { check } from 'meteor/check';
 import { TasksCollection } from '../db/TasksCollection';
 
 Meteor.methods({
-  'tasks.insert'(text) {
+  async 'tasks.insert'(text) {
     check(text, String);
 
     if (!this.userId) {
       throw new Meteor.Error('Not authorized.');
     }
 
-    TasksCollection.insert({
+    await TasksCollection.insertAsync({
       text,
       createdAt: new Date(),
       userId: this.userId,
     });
   },
 
-  'tasks.remove'(taskId) {
+  async 'tasks.remove'(taskId) {
     check(taskId, String);
 
     if (!this.userId) {
       throw new Meteor.Error('Not authorized.');
     }
 
-    const task = TasksCollection.findOne({ _id: taskId, userId: this.userId });
+    const task = await TasksCollection.findOneAsync({ _id: taskId, userId: this.userId });
 
     if (!task) {
       throw new Meteor.Error('Access denied.');
     }
 
-    TasksCollection.remove(taskId);
+    await TasksCollection.removeAsync(taskId);
   },
 
-  'tasks.setIsChecked'(taskId, isChecked) {
+  async 'tasks.setIsChecked'(taskId, isChecked) {
     check(taskId, String);
     check(isChecked, Boolean);
 
@@ -41,13 +41,13 @@ Meteor.methods({
       throw new Meteor.Error('Not authorized.');
     }
 
-    const task = TasksCollection.findOne({ _id: taskId, userId: this.userId });
+    const task = await TasksCollection.findOneAsync({ _id: taskId, userId: this.userId });
 
     if (!task) {
       throw new Meteor.Error('Access denied.');
     }
 
-    TasksCollection.update(taskId, {
+    await TasksCollection.updateAsync(taskId, {
       $set: {
         isChecked,
       },

--- a/src/simple-todos/step09/imports/ui/App.js
+++ b/src/simple-todos/step09/imports/ui/App.js
@@ -45,7 +45,7 @@ Template.mainContainer.events({
 });
 
 Template.mainContainer.helpers({
-  tasks() {
+  async tasks() {
     const instance = Template.instance();
     const hideCompleted = instance.state.get(HIDE_COMPLETED_STRING);
 
@@ -55,26 +55,26 @@ Template.mainContainer.helpers({
       return [];
     }
 
-    return TasksCollection.find(
+    return await TasksCollection.find(
       hideCompleted ? pendingOnlyFilter : userFilter,
       {
         sort: { createdAt: -1 },
       }
-    ).fetch();
+    ).fetchAsync();
   },
   hideCompleted() {
     return Template.instance().state.get(HIDE_COMPLETED_STRING);
   },
-  incompleteCount() {
+  async incompleteCount() {
     if (!isUserLogged()) {
       return '';
     }
 
     const { pendingOnlyFilter } = getTasksFilter();
 
-    const incompleteTasksCount = TasksCollection.find(
+    const incompleteTasksCount = await TasksCollection.find(
       pendingOnlyFilter
-    ).count();
+    ).countAsync();
     return incompleteTasksCount ? `(${incompleteTasksCount})` : '';
   },
   isUserLogged() {

--- a/src/simple-todos/step09/server/main.js
+++ b/src/simple-todos/step09/server/main.js
@@ -4,8 +4,8 @@ import { TasksCollection } from '/imports/db/TasksCollection';
 import '/imports/api/tasksMethods';
 import '/imports/api/tasksPublications';
 
-const insertTask = (taskText, user) =>
-  TasksCollection.insert({
+const insertTask = async (taskText, user) =>
+  TasksCollection.insertAsync({
     text: taskText,
     userId: user._id,
     createdAt: new Date(),
@@ -14,7 +14,7 @@ const insertTask = (taskText, user) =>
 const SEED_USERNAME = 'meteorite';
 const SEED_PASSWORD = 'password';
 
-Meteor.startup(() => {
+Meteor.startup(async () => {
   if (!Accounts.findUserByUsername(SEED_USERNAME)) {
     Accounts.createUser({
       username: SEED_USERNAME,
@@ -24,7 +24,7 @@ Meteor.startup(() => {
 
   const user = Accounts.findUserByUsername(SEED_USERNAME);
 
-  if (TasksCollection.find().count() === 0) {
+  if (await TasksCollection.find().countAsync() === 0) {
     [
       'First Task',
       'Second Task',

--- a/src/simple-todos/step09/server/main.js
+++ b/src/simple-todos/step09/server/main.js
@@ -5,7 +5,7 @@ import '/imports/api/tasksMethods';
 import '/imports/api/tasksPublications';
 
 const insertTask = async (taskText, user) =>
-  TasksCollection.insertAsync({
+  await TasksCollection.insertAsync({
     text: taskText,
     userId: user._id,
     createdAt: new Date(),

--- a/src/simple-todos/step10/imports/api/tasksMethods.js
+++ b/src/simple-todos/step10/imports/api/tasksMethods.js
@@ -3,37 +3,37 @@ import { check } from 'meteor/check';
 import { TasksCollection } from '../db/TasksCollection';
 
 Meteor.methods({
-  'tasks.insert'(text) {
+  async 'tasks.insert'(text) {
     check(text, String);
 
     if (!this.userId) {
       throw new Meteor.Error('Not authorized.');
     }
 
-    TasksCollection.insert({
+    await TasksCollection.insertAsync({
       text,
       createdAt: new Date(),
       userId: this.userId,
     });
   },
 
-  'tasks.remove'(taskId) {
+  async 'tasks.remove'(taskId) {
     check(taskId, String);
 
     if (!this.userId) {
       throw new Meteor.Error('Not authorized.');
     }
 
-    const task = TasksCollection.findOne({ _id: taskId, userId: this.userId });
+    const task = await TasksCollection.findOneAsync({ _id: taskId, userId: this.userId });
 
     if (!task) {
       throw new Meteor.Error('Access denied.');
     }
 
-    TasksCollection.remove(taskId);
+    await TasksCollection.removeAsync(taskId);
   },
 
-  'tasks.setIsChecked'(taskId, isChecked) {
+  async 'tasks.setIsChecked'(taskId, isChecked) {
     check(taskId, String);
     check(isChecked, Boolean);
 
@@ -41,13 +41,13 @@ Meteor.methods({
       throw new Meteor.Error('Not authorized.');
     }
 
-    const task = TasksCollection.findOne({ _id: taskId, userId: this.userId });
+    const task = await TasksCollection.findOneAsync({ _id: taskId, userId: this.userId });
 
     if (!task) {
       throw new Meteor.Error('Access denied.');
     }
 
-    TasksCollection.update(taskId, {
+    await TasksCollection.updateAsync(taskId, {
       $set: {
         isChecked,
       },

--- a/src/simple-todos/step10/imports/ui/App.js
+++ b/src/simple-todos/step10/imports/ui/App.js
@@ -45,7 +45,7 @@ Template.mainContainer.events({
 });
 
 Template.mainContainer.helpers({
-  tasks() {
+  async tasks() {
     const instance = Template.instance();
     const hideCompleted = instance.state.get(HIDE_COMPLETED_STRING);
 
@@ -55,26 +55,26 @@ Template.mainContainer.helpers({
       return [];
     }
 
-    return TasksCollection.find(
+    return await TasksCollection.find(
       hideCompleted ? pendingOnlyFilter : userFilter,
       {
         sort: { createdAt: -1 },
       }
-    ).fetch();
+    ).fetchAsync();
   },
   hideCompleted() {
     return Template.instance().state.get(HIDE_COMPLETED_STRING);
   },
-  incompleteCount() {
+  async incompleteCount() {
     if (!isUserLogged()) {
       return '';
     }
 
     const { pendingOnlyFilter } = getTasksFilter();
 
-    const incompleteTasksCount = TasksCollection.find(
+    const incompleteTasksCount = await TasksCollection.find(
       pendingOnlyFilter
-    ).count();
+    ).countAsync();
     return incompleteTasksCount ? `(${incompleteTasksCount})` : '';
   },
   isUserLogged() {

--- a/src/simple-todos/step10/server/main.js
+++ b/src/simple-todos/step10/server/main.js
@@ -4,8 +4,8 @@ import { TasksCollection } from '/imports/db/TasksCollection';
 import '/imports/api/tasksMethods';
 import '/imports/api/tasksPublications';
 
-const insertTask = (taskText, user) =>
-  TasksCollection.insert({
+const insertTask = async (taskText, user) =>
+  TasksCollection.insertAsync({
     text: taskText,
     userId: user._id,
     createdAt: new Date(),
@@ -14,7 +14,7 @@ const insertTask = (taskText, user) =>
 const SEED_USERNAME = 'meteorite';
 const SEED_PASSWORD = 'password';
 
-Meteor.startup(() => {
+Meteor.startup(async () => {
   if (!Accounts.findUserByUsername(SEED_USERNAME)) {
     Accounts.createUser({
       username: SEED_USERNAME,
@@ -24,7 +24,7 @@ Meteor.startup(() => {
 
   const user = Accounts.findUserByUsername(SEED_USERNAME);
 
-  if (TasksCollection.find().count() === 0) {
+  if (await TasksCollection.find().countAsync() === 0) {
     [
       'First Task',
       'Second Task',

--- a/src/simple-todos/step10/server/main.js
+++ b/src/simple-todos/step10/server/main.js
@@ -5,7 +5,7 @@ import '/imports/api/tasksMethods';
 import '/imports/api/tasksPublications';
 
 const insertTask = async (taskText, user) =>
-  TasksCollection.insertAsync({
+  await TasksCollection.insertAsync({
     text: taskText,
     userId: user._id,
     createdAt: new Date(),

--- a/src/simple-todos/step11/imports/api/tasksMethods.js
+++ b/src/simple-todos/step11/imports/api/tasksMethods.js
@@ -3,37 +3,37 @@ import { check } from 'meteor/check';
 import { TasksCollection } from '../db/TasksCollection';
 
 Meteor.methods({
-  'tasks.insert'(text) {
+  async 'tasks.insert'(text) {
     check(text, String);
 
     if (!this.userId) {
       throw new Meteor.Error('Not authorized.');
     }
 
-    TasksCollection.insert({
+    await TasksCollection.insertAsync({
       text,
       createdAt: new Date(),
       userId: this.userId,
     });
   },
 
-  'tasks.remove'(taskId) {
+  async 'tasks.remove'(taskId) {
     check(taskId, String);
 
     if (!this.userId) {
       throw new Meteor.Error('Not authorized.');
     }
 
-    const task = TasksCollection.findOne({ _id: taskId, userId: this.userId });
+    const task = await TasksCollection.findOneAsync({ _id: taskId, userId: this.userId });
 
     if (!task) {
       throw new Meteor.Error('Access denied.');
     }
 
-    TasksCollection.remove(taskId);
+    await TasksCollection.removeAsync(taskId);
   },
 
-  'tasks.setIsChecked'(taskId, isChecked) {
+  async 'tasks.setIsChecked'(taskId, isChecked) {
     check(taskId, String);
     check(isChecked, Boolean);
 
@@ -41,13 +41,13 @@ Meteor.methods({
       throw new Meteor.Error('Not authorized.');
     }
 
-    const task = TasksCollection.findOne({ _id: taskId, userId: this.userId });
+    const task = await TasksCollection.findOneAsync({ _id: taskId, userId: this.userId });
 
     if (!task) {
       throw new Meteor.Error('Access denied.');
     }
 
-    TasksCollection.update(taskId, {
+    await TasksCollection.updateAsync(taskId, {
       $set: {
         isChecked,
       },

--- a/src/simple-todos/step11/imports/api/tasksMethods.tests.js
+++ b/src/simple-todos/step11/imports/api/tasksMethods.tests.js
@@ -11,53 +11,53 @@ if (Meteor.isServer) {
       const userId = Random.id();
       let taskId;
 
-      beforeEach(() => {
-        TasksCollection.remove({});
-        taskId = TasksCollection.insert({
+      beforeEach(async () => {
+        await TasksCollection.removeAsync({});
+        taskId = await TasksCollection.insertAsync({
           text: 'Test Task',
           createdAt: new Date(),
           userId,
         });
       });
 
-      it('can delete owned task', () => {
+      it('can delete owned task', async () => {
         mockMethodCall('tasks.remove', taskId, { context: { userId } });
 
-        assert.equal(TasksCollection.find().count(), 0);
+        assert.equal(await TasksCollection.find().countAsync(), 0);
       });
 
-      it("can't delete task without an user authenticated", () => {
+      it("can't delete task without an user authenticated", async () => {
         const fn = () => mockMethodCall('tasks.remove', taskId);
         assert.throw(fn, /Not authorized/);
-        assert.equal(TasksCollection.find().count(), 1);
+        assert.equal(await TasksCollection.find().countAsync(), 1);
       });
 
-      it("can't delete task from another owner", () => {
+      it("can't delete task from another owner", async () => {
         const fn = () =>
           mockMethodCall('tasks.remove', taskId, {
             context: { userId: 'somebody-else-id' },
           });
         assert.throw(fn, /Access denied/);
-        assert.equal(TasksCollection.find().count(), 1);
+        assert.equal(await TasksCollection.find().countAsync(), 1);
       });
 
-      it('can change the status of a task', () => {
-        const originalTask = TasksCollection.findOne(taskId);
+      it('can change the status of a task', async () => {
+        const originalTask = await TasksCollection.findOneAsync(taskId);
         mockMethodCall('tasks.setIsChecked', taskId, !originalTask.isChecked, {
           context: { userId },
         });
 
-        const updatedTask = TasksCollection.findOne(taskId);
+        const updatedTask = await TasksCollection.findOneAsync(taskId);
         assert.notEqual(updatedTask.isChecked, originalTask.isChecked);
       });
 
-      it('can insert new tasks', () => {
+      it('can insert new tasks', async () => {
         const text = 'New Task';
         mockMethodCall('tasks.insert', text, {
           context: { userId },
         });
 
-        const tasks = TasksCollection.find({}).fetch();
+        const tasks =   await TasksCollection.find({}).fetchAsync();
         assert.equal(tasks.length, 2);
         assert.isTrue(tasks.some(task => task.text === text));
       });

--- a/src/simple-todos/step11/imports/ui/App.js
+++ b/src/simple-todos/step11/imports/ui/App.js
@@ -45,7 +45,7 @@ Template.mainContainer.events({
 });
 
 Template.mainContainer.helpers({
-  tasks() {
+  async tasks() {
     const instance = Template.instance();
     const hideCompleted = instance.state.get(HIDE_COMPLETED_STRING);
 
@@ -55,26 +55,26 @@ Template.mainContainer.helpers({
       return [];
     }
 
-    return TasksCollection.find(
+    return await TasksCollection.find(
       hideCompleted ? pendingOnlyFilter : userFilter,
       {
         sort: { createdAt: -1 },
       }
-    ).fetch();
+    ).fetchAsync();
   },
   hideCompleted() {
     return Template.instance().state.get(HIDE_COMPLETED_STRING);
   },
-  incompleteCount() {
+  async incompleteCount() {
     if (!isUserLogged()) {
       return '';
     }
 
     const { pendingOnlyFilter } = getTasksFilter();
 
-    const incompleteTasksCount = TasksCollection.find(
+    const incompleteTasksCount = await TasksCollection.find(
       pendingOnlyFilter
-    ).count();
+    ).countAsync();
     return incompleteTasksCount ? `(${incompleteTasksCount})` : '';
   },
   isUserLogged() {

--- a/src/simple-todos/step11/server/main.js
+++ b/src/simple-todos/step11/server/main.js
@@ -4,8 +4,8 @@ import { TasksCollection } from '/imports/db/TasksCollection';
 import '/imports/api/tasksMethods';
 import '/imports/api/tasksPublications';
 
-const insertTask = (taskText, user) =>
-  TasksCollection.insert({
+const insertTask = async (taskText, user) =>
+  TasksCollection.insertAsync({
     text: taskText,
     userId: user._id,
     createdAt: new Date(),
@@ -14,7 +14,7 @@ const insertTask = (taskText, user) =>
 const SEED_USERNAME = 'meteorite';
 const SEED_PASSWORD = 'password';
 
-Meteor.startup(() => {
+Meteor.startup(async () => {
   if (!Accounts.findUserByUsername(SEED_USERNAME)) {
     Accounts.createUser({
       username: SEED_USERNAME,
@@ -24,7 +24,7 @@ Meteor.startup(() => {
 
   const user = Accounts.findUserByUsername(SEED_USERNAME);
 
-  if (TasksCollection.find().count() === 0) {
+  if (await TasksCollection.find().countAsync() === 0) {
     [
       'First Task',
       'Second Task',

--- a/src/simple-todos/step11/server/main.js
+++ b/src/simple-todos/step11/server/main.js
@@ -5,7 +5,7 @@ import '/imports/api/tasksMethods';
 import '/imports/api/tasksPublications';
 
 const insertTask = async (taskText, user) =>
-  TasksCollection.insertAsync({
+  await TasksCollection.insertAsync({
     text: taskText,
     userId: user._id,
     createdAt: new Date(),

--- a/src/simple-todos/step12/imports/api/tasksMethods.js
+++ b/src/simple-todos/step12/imports/api/tasksMethods.js
@@ -3,37 +3,37 @@ import { check } from 'meteor/check';
 import { TasksCollection } from '../db/TasksCollection';
 
 Meteor.methods({
-  'tasks.insert'(text) {
+  async 'tasks.insert'(text) {
     check(text, String);
 
     if (!this.userId) {
       throw new Meteor.Error('Not authorized.');
     }
 
-    TasksCollection.insert({
+    await TasksCollection.insertAsync({
       text,
       createdAt: new Date(),
       userId: this.userId,
     });
   },
 
-  'tasks.remove'(taskId) {
+  async 'tasks.remove'(taskId) {
     check(taskId, String);
 
     if (!this.userId) {
       throw new Meteor.Error('Not authorized.');
     }
 
-    const task = TasksCollection.findOne({ _id: taskId, userId: this.userId });
+    const task = await TasksCollection.findOneAsync({ _id: taskId, userId: this.userId });
 
     if (!task) {
       throw new Meteor.Error('Access denied.');
     }
 
-    TasksCollection.remove(taskId);
+    await TasksCollection.removeAsync(taskId);
   },
 
-  'tasks.setIsChecked'(taskId, isChecked) {
+  async 'tasks.setIsChecked'(taskId, isChecked) {
     check(taskId, String);
     check(isChecked, Boolean);
 
@@ -41,13 +41,13 @@ Meteor.methods({
       throw new Meteor.Error('Not authorized.');
     }
 
-    const task = TasksCollection.findOne({ _id: taskId, userId: this.userId });
+    const task = await TasksCollection.findOneAsync({ _id: taskId, userId: this.userId });
 
     if (!task) {
       throw new Meteor.Error('Access denied.');
     }
 
-    TasksCollection.update(taskId, {
+    await TasksCollection.updateAsync(taskId, {
       $set: {
         isChecked,
       },

--- a/src/simple-todos/step12/imports/api/tasksMethods.tests.js
+++ b/src/simple-todos/step12/imports/api/tasksMethods.tests.js
@@ -11,53 +11,53 @@ if (Meteor.isServer) {
       const userId = Random.id();
       let taskId;
 
-      beforeEach(() => {
-        TasksCollection.remove({});
-        taskId = TasksCollection.insert({
+      beforeEach(async () => {
+        await TasksCollection.removeAsync({});
+        taskId = await TasksCollection.insertAsync({
           text: 'Test Task',
           createdAt: new Date(),
           userId,
         });
       });
 
-      it('can delete owned task', () => {
+      it('can delete owned task', async () => {
         mockMethodCall('tasks.remove', taskId, { context: { userId } });
 
-        assert.equal(TasksCollection.find().count(), 0);
+        assert.equal(await TasksCollection.find().countAsync(), 0);
       });
 
-      it("can't delete task without an user authenticated", () => {
+      it("can't delete task without an user authenticated", async () => {
         const fn = () => mockMethodCall('tasks.remove', taskId);
         assert.throw(fn, /Not authorized/);
-        assert.equal(TasksCollection.find().count(), 1);
+        assert.equal(await TasksCollection.find().countAsync(), 1);
       });
 
-      it("can't delete task from another owner", () => {
+      it("can't delete task from another owner", async () => {
         const fn = () =>
           mockMethodCall('tasks.remove', taskId, {
             context: { userId: 'somebody-else-id' },
           });
         assert.throw(fn, /Access denied/);
-        assert.equal(TasksCollection.find().count(), 1);
+        assert.equal(await TasksCollection.find().countAsync(), 1);
       });
 
-      it('can change the status of a task', () => {
-        const originalTask = TasksCollection.findOne(taskId);
+      it('can change the status of a task', async () => {
+        const originalTask = await TasksCollection.findOneAsync(taskId);
         mockMethodCall('tasks.setIsChecked', taskId, !originalTask.isChecked, {
           context: { userId },
         });
 
-        const updatedTask = TasksCollection.findOne(taskId);
+        const updatedTask = await TasksCollection.findOneAsync(taskId);
         assert.notEqual(updatedTask.isChecked, originalTask.isChecked);
       });
 
-      it('can insert new tasks', () => {
+      it('can insert new tasks', async () => {
         const text = 'New Task';
         mockMethodCall('tasks.insert', text, {
           context: { userId },
         });
 
-        const tasks = TasksCollection.find({}).fetch();
+        const tasks =   await TasksCollection.find({}).fetchAsync();
         assert.equal(tasks.length, 2);
         assert.isTrue(tasks.some(task => task.text === text));
       });

--- a/src/simple-todos/step12/imports/ui/App.js
+++ b/src/simple-todos/step12/imports/ui/App.js
@@ -45,7 +45,7 @@ Template.mainContainer.events({
 });
 
 Template.mainContainer.helpers({
-  tasks() {
+  async tasks() {
     const instance = Template.instance();
     const hideCompleted = instance.state.get(HIDE_COMPLETED_STRING);
 
@@ -55,26 +55,26 @@ Template.mainContainer.helpers({
       return [];
     }
 
-    return TasksCollection.find(
+    return await TasksCollection.find(
       hideCompleted ? pendingOnlyFilter : userFilter,
       {
         sort: { createdAt: -1 },
       }
-    ).fetch();
+    ).fetchAsync();
   },
   hideCompleted() {
     return Template.instance().state.get(HIDE_COMPLETED_STRING);
   },
-  incompleteCount() {
+  async incompleteCount() {
     if (!isUserLogged()) {
       return '';
     }
 
     const { pendingOnlyFilter } = getTasksFilter();
 
-    const incompleteTasksCount = TasksCollection.find(
+    const incompleteTasksCount = await TasksCollection.find(
       pendingOnlyFilter
-    ).count();
+    ).countAsync();
     return incompleteTasksCount ? `(${incompleteTasksCount})` : '';
   },
   isUserLogged() {

--- a/src/simple-todos/step12/server/main.js
+++ b/src/simple-todos/step12/server/main.js
@@ -4,8 +4,8 @@ import { TasksCollection } from '/imports/db/TasksCollection';
 import '/imports/api/tasksMethods';
 import '/imports/api/tasksPublications';
 
-const insertTask = (taskText, user) =>
-  TasksCollection.insert({
+const insertTask = async (taskText, user) =>
+  TasksCollection.insertAsync({
     text: taskText,
     userId: user._id,
     createdAt: new Date(),
@@ -14,7 +14,7 @@ const insertTask = (taskText, user) =>
 const SEED_USERNAME = 'meteorite';
 const SEED_PASSWORD = 'password';
 
-Meteor.startup(() => {
+Meteor.startup(async () => {
   if (!Accounts.findUserByUsername(SEED_USERNAME)) {
     Accounts.createUser({
       username: SEED_USERNAME,
@@ -24,7 +24,7 @@ Meteor.startup(() => {
 
   const user = Accounts.findUserByUsername(SEED_USERNAME);
 
-  if (TasksCollection.find().count() === 0) {
+  if (await TasksCollection.find().countAsync() === 0) {
     [
       'First Task',
       'Second Task',

--- a/src/simple-todos/step12/server/main.js
+++ b/src/simple-todos/step12/server/main.js
@@ -5,7 +5,7 @@ import '/imports/api/tasksMethods';
 import '/imports/api/tasksPublications';
 
 const insertTask = async (taskText, user) =>
-  TasksCollection.insertAsync({
+  await TasksCollection.insertAsync({
     text: taskText,
     userId: user._id,
     createdAt: new Date(),

--- a/src/simple-todos/step13/imports/api/tasksMethods.js
+++ b/src/simple-todos/step13/imports/api/tasksMethods.js
@@ -3,37 +3,37 @@ import { check } from 'meteor/check';
 import { TasksCollection } from '../db/TasksCollection';
 
 Meteor.methods({
-  'tasks.insert'(text) {
+  async 'tasks.insert'(text) {
     check(text, String);
 
     if (!this.userId) {
       throw new Meteor.Error('Not authorized.');
     }
 
-    TasksCollection.insert({
+    await TasksCollection.insertAsync({
       text,
       createdAt: new Date(),
       userId: this.userId,
     });
   },
 
-  'tasks.remove'(taskId) {
+  async 'tasks.remove'(taskId) {
     check(taskId, String);
 
     if (!this.userId) {
       throw new Meteor.Error('Not authorized.');
     }
 
-    const task = TasksCollection.findOne({ _id: taskId, userId: this.userId });
+    const task = await TasksCollection.findOneAsync({ _id: taskId, userId: this.userId });
 
     if (!task) {
       throw new Meteor.Error('Access denied.');
     }
 
-    TasksCollection.remove(taskId);
+    await TasksCollection.removeAsync(taskId);
   },
 
-  'tasks.setIsChecked'(taskId, isChecked) {
+  async 'tasks.setIsChecked'(taskId, isChecked) {
     check(taskId, String);
     check(isChecked, Boolean);
 
@@ -41,13 +41,13 @@ Meteor.methods({
       throw new Meteor.Error('Not authorized.');
     }
 
-    const task = TasksCollection.findOne({ _id: taskId, userId: this.userId });
+    const task = await TasksCollection.findOneAsync({ _id: taskId, userId: this.userId });
 
     if (!task) {
       throw new Meteor.Error('Access denied.');
     }
 
-    TasksCollection.update(taskId, {
+    await TasksCollection.updateAsync(taskId, {
       $set: {
         isChecked,
       },

--- a/src/simple-todos/step13/imports/api/tasksMethods.tests.js
+++ b/src/simple-todos/step13/imports/api/tasksMethods.tests.js
@@ -11,53 +11,53 @@ if (Meteor.isServer) {
       const userId = Random.id();
       let taskId;
 
-      beforeEach(() => {
-        TasksCollection.remove({});
-        taskId = TasksCollection.insert({
+      beforeEach(async () => {
+        await TasksCollection.removeAsync({});
+        taskId = await TasksCollection.insertAsync({
           text: 'Test Task',
           createdAt: new Date(),
           userId,
         });
       });
 
-      it('can delete owned task', () => {
+      it('can delete owned task', async () => {
         mockMethodCall('tasks.remove', taskId, { context: { userId } });
 
-        assert.equal(TasksCollection.find().count(), 0);
+        assert.equal(await TasksCollection.find().countAsync(), 0);
       });
 
-      it("can't delete task without an user authenticated", () => {
+      it("can't delete task without an user authenticated", async () => {
         const fn = () => mockMethodCall('tasks.remove', taskId);
         assert.throw(fn, /Not authorized/);
-        assert.equal(TasksCollection.find().count(), 1);
+        assert.equal(await TasksCollection.find().countAsync(), 1);
       });
 
-      it("can't delete task from another owner", () => {
+      it("can't delete task from another owner", async () => {
         const fn = () =>
           mockMethodCall('tasks.remove', taskId, {
             context: { userId: 'somebody-else-id' },
           });
         assert.throw(fn, /Access denied/);
-        assert.equal(TasksCollection.find().count(), 1);
+        assert.equal(await TasksCollection.find().countAsync(), 1);
       });
 
-      it('can change the status of a task', () => {
-        const originalTask = TasksCollection.findOne(taskId);
+      it('can change the status of a task', async () => {
+        const originalTask = await TasksCollection.findOneAsync(taskId);
         mockMethodCall('tasks.setIsChecked', taskId, !originalTask.isChecked, {
           context: { userId },
         });
 
-        const updatedTask = TasksCollection.findOne(taskId);
+        const updatedTask = await TasksCollection.findOneAsync(taskId);
         assert.notEqual(updatedTask.isChecked, originalTask.isChecked);
       });
 
-      it('can insert new tasks', () => {
+      it('can insert new tasks', async () => {
         const text = 'New Task';
         mockMethodCall('tasks.insert', text, {
           context: { userId },
         });
 
-        const tasks = TasksCollection.find({}).fetch();
+        const tasks =   await TasksCollection.find({}).fetchAsync();
         assert.equal(tasks.length, 2);
         assert.isTrue(tasks.some(task => task.text === text));
       });

--- a/src/simple-todos/step13/imports/ui/App.js
+++ b/src/simple-todos/step13/imports/ui/App.js
@@ -45,7 +45,7 @@ Template.mainContainer.events({
 });
 
 Template.mainContainer.helpers({
-  tasks() {
+  async tasks() {
     const instance = Template.instance();
     const hideCompleted = instance.state.get(HIDE_COMPLETED_STRING);
 
@@ -55,26 +55,26 @@ Template.mainContainer.helpers({
       return [];
     }
 
-    return TasksCollection.find(
+    return await TasksCollection.find(
       hideCompleted ? pendingOnlyFilter : userFilter,
       {
         sort: { createdAt: -1 },
       }
-    ).fetch();
+    ).fetchAsync();
   },
   hideCompleted() {
     return Template.instance().state.get(HIDE_COMPLETED_STRING);
   },
-  incompleteCount() {
+  async incompleteCount() {
     if (!isUserLogged()) {
       return '';
     }
 
     const { pendingOnlyFilter } = getTasksFilter();
 
-    const incompleteTasksCount = TasksCollection.find(
+    const incompleteTasksCount = await TasksCollection.find(
       pendingOnlyFilter
-    ).count();
+    ).countAsync();
     return incompleteTasksCount ? `(${incompleteTasksCount})` : '';
   },
   isUserLogged() {

--- a/src/simple-todos/step13/server/main.js
+++ b/src/simple-todos/step13/server/main.js
@@ -4,8 +4,8 @@ import { TasksCollection } from '/imports/db/TasksCollection';
 import '/imports/api/tasksMethods';
 import '/imports/api/tasksPublications';
 
-const insertTask = (taskText, user) =>
-  TasksCollection.insert({
+const insertTask = async (taskText, user) =>
+  TasksCollection.insertAsync({
     text: taskText,
     userId: user._id,
     createdAt: new Date(),
@@ -14,7 +14,7 @@ const insertTask = (taskText, user) =>
 const SEED_USERNAME = 'meteorite';
 const SEED_PASSWORD = 'password';
 
-Meteor.startup(() => {
+Meteor.startup(async () => {
   if (!Accounts.findUserByUsername(SEED_USERNAME)) {
     Accounts.createUser({
       username: SEED_USERNAME,
@@ -24,7 +24,7 @@ Meteor.startup(() => {
 
   const user = Accounts.findUserByUsername(SEED_USERNAME);
 
-  if (TasksCollection.find().count() === 0) {
+  if (await TasksCollection.find().countAsync() === 0) {
     [
       'First Task',
       'Second Task',

--- a/src/simple-todos/step13/server/main.js
+++ b/src/simple-todos/step13/server/main.js
@@ -5,7 +5,7 @@ import '/imports/api/tasksMethods';
 import '/imports/api/tasksPublications';
 
 const insertTask = async (taskText, user) =>
-  TasksCollection.insertAsync({
+  await TasksCollection.insertAsync({
     text: taskText,
     userId: user._id,
     createdAt: new Date(),

--- a/tutorial/changelog.md
+++ b/tutorial/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+v1.2 - 02/08/2022
+
+- Updates in Mongo Async API.
+
 v1.1 - 06/06/2022
 
 - Tutorial Review.

--- a/tutorial/simple-todos/02-collections.md
+++ b/tutorial/simple-todos/02-collections.md
@@ -40,10 +40,11 @@ You don't need to keep the old content of `server/main.js`.
 import { Meteor } from 'meteor/meteor';
 import { TasksCollection } from '/imports/api/TasksCollection';
 
-const insertTask = taskText => TasksCollection.insert({ text: taskText });
- 
-Meteor.startup(() => {
-  if (TasksCollection.find().count() === 0) {
+const insertTask = async (taskText) =>
+  await TasksCollection.insertAsync({ text: taskText });
+
+Meteor.startup(async () => {
+  if (TasksCollection.find().countAsync() === 0) {
     [
       'First Task',
       'Second Task',
@@ -51,8 +52,8 @@ Meteor.startup(() => {
       'Fourth Task',
       'Fifth Task',
       'Sixth Task',
-      'Seventh Task'
-    ].forEach(insertTask)
+      'Seventh Task',
+    ].forEach(insertTask);
   }
 });
 ```

--- a/tutorial/simple-todos/03-forms-and-events.md
+++ b/tutorial/simple-todos/03-forms-and-events.md
@@ -80,23 +80,23 @@ Now we need to add a listener to the `submit` event on the form:
 });
 
 Template.form.events({
-  "submit .task-form"(event) {
+  async 'submit .task-form'(event) {
     // Prevent default browser form submit
     event.preventDefault();
 
     // Get value from form element
-    const target = event.target;
+    const { target } = event;
     const text = target.text.value;
 
     // Insert a task into the collection
-    TasksCollection.insert({
+    await TasksCollection.insertAsync({
       text,
       createdAt: new Date(), // current time
     });
 
     // Clear form
     target.text.value = '';
-  }
+  },
 })
 ```
 

--- a/tutorial/simple-todos/04-update-and-remove.md
+++ b/tutorial/simple-todos/04-update-and-remove.md
@@ -39,9 +39,9 @@ import { TasksCollection } from "../api/TasksCollection";
 import './Task.html';
 
 Template.task.events({
-  'click .toggle-checked'() {
+  async 'click .toggle-checked'() {
     // Set the checked property to the opposite of its current value
-    TasksCollection.update(this._id, {
+    await TasksCollection.updateAsync(this._id, {
       $set: { isChecked: !this.isChecked },
     });
   },
@@ -93,8 +93,8 @@ Now add the removal logic in the `Task.js`. It will just be a new event to the `
 
 Template.task.events({
   ...,
-  'click .delete'() {
-    TasksCollection.remove(this._id);
+  async 'click .delete'() {
+    await TasksCollection.removeAsync(this._id);
   },
 });
 ```

--- a/tutorial/simple-todos/06-filter-tasks.md
+++ b/tutorial/simple-todos/06-filter-tasks.md
@@ -110,18 +110,15 @@ Now, we need to update `Template.mainContainer.helpers`. The code below verifies
 ...
 
 Template.mainContainer.helpers({
-  tasks() {
+  async tasks() {
     const instance = Template.instance();
     const hideCompleted = instance.state.get(HIDE_COMPLETED_STRING);
 
     const hideCompletedFilter = { isChecked: { $ne: true } };
 
-    return TasksCollection.find(hideCompleted ? hideCompletedFilter : {}, {
+    return await TasksCollection.find(hideCompleted ? hideCompletedFilter : {}, {
       sort: { createdAt: -1 },
-    }).fetch();
-  },
-  hideCompleted() {
-    return Template.instance().state.get(HIDE_COMPLETED_STRING);
+    }).fetchAsync();
   },
 });
 
@@ -154,8 +151,10 @@ You should avoid adding zero to your app bar when there are no pending tasks.
 
 Template.mainContainer.helpers({
   ...,
-  incompleteCount() {
-    const incompleteTasksCount = TasksCollection.find({ isChecked: { $ne: true } }).count();
+  async incompleteCount() {
+    const incompleteTasksCount = await TasksCollection.find({
+      isChecked: { $ne: true },
+    }).countAsync();
     return incompleteTasksCount ? `(${incompleteTasksCount})` : '';
   },
 });

--- a/tutorial/simple-todos/08-methods.md
+++ b/tutorial/simple-todos/08-methods.md
@@ -57,44 +57,44 @@ import { check } from 'meteor/check';
 import { TasksCollection } from './TasksCollection';
  
 Meteor.methods({
-  'tasks.insert'(text) {
+  async 'tasks.insert'(text) {
     check(text, String);
- 
+
     if (!this.userId) {
       throw new Meteor.Error('Not authorized.');
     }
- 
-    TasksCollection.insert({
+
+    await TasksCollection.insertAsync({
       text,
-      createdAt: new Date,
+      createdAt: new Date(),
       userId: this.userId,
-    })
+    });
   },
- 
-  'tasks.remove'(taskId) {
+
+  async 'tasks.remove'(taskId) {
     check(taskId, String);
- 
+
     if (!this.userId) {
       throw new Meteor.Error('Not authorized.');
     }
- 
-    TasksCollection.remove(taskId);
+
+    await TasksCollection.removeAsync(taskId);
   },
- 
-  'tasks.setIsChecked'(taskId, isChecked) {
+
+  async 'tasks.setIsChecked'(taskId, isChecked) {
     check(taskId, String);
     check(isChecked, Boolean);
- 
+
     if (!this.userId) {
       throw new Meteor.Error('Not authorized.');
     }
- 
-    TasksCollection.update(taskId, {
+
+    await TasksCollection.updateAsync(taskId, {
       $set: {
-        isChecked
-      }
+        isChecked,
+      },
     });
-  }
+  },
 });
 ```
 

--- a/tutorial/simple-todos/09-publications.md
+++ b/tutorial/simple-todos/09-publications.md
@@ -137,44 +137,44 @@ Only the owner of a task should be able to change certain things. You should cha
 `imports/api/tasksMethods.js`
 
 ```js
-..
-  'tasks.remove'(taskId) {
-    check(taskId, String);
+...
+    async 'tasks.remove'(taskId) {
+      check(taskId, String);
+    
+      if (!this.userId) {
+        throw new Meteor.Error('Not authorized.');
+      }
+    
+      const task = await TasksCollection.findOneAsync({ _id: taskId, userId: this.userId });
+    
+      if (!task) {
+        throw new Meteor.Error('Access denied.');
+      }
+    
+      await TasksCollection.removeAsync(taskId);
+    },
 
-    if (!this.userId) {
-      throw new Meteor.Error('Not authorized.');
-    }
-
-    const task = TasksCollection.findOne({ _id: taskId, userId: this.userId });
-
-    if (!task) {
-      throw new Meteor.Error('Access denied.');
-    }
-
-    TasksCollection.remove(taskId);
-  },
-
-  'tasks.setIsChecked'(taskId, isChecked) {
-    check(taskId, String);
-    check(isChecked, Boolean);
-
-    if (!this.userId) {
-      throw new Meteor.Error('Not authorized.');
-    }
-
-    const task = TasksCollection.findOne({ _id: taskId, userId: this.userId });
-
-    if (!task) {
-      throw new Meteor.Error('Access denied.');
-    }
-
-    TasksCollection.update(taskId, {
-      $set: {
-        isChecked,
-      },
-    });
-  },
-..
+    async 'tasks.setIsChecked'(taskId, isChecked) {
+      check(taskId, String);
+      check(isChecked, Boolean);
+    
+      if (!this.userId) {
+        throw new Meteor.Error('Not authorized.');
+      }
+    
+      const task = await TasksCollection.findOneAsync({ _id: taskId, userId: this.userId });
+    
+      if (!task) {
+        throw new Meteor.Error('Access denied.');
+      }
+    
+      await TasksCollection.updateAsync(taskId, {
+        $set: {
+          isChecked,
+        },
+      });
+    },
+...
 ```
 
 Why is this important if we are not returning tasks from other users in the client?

--- a/tutorial/simple-todos/11-testing.md
+++ b/tutorial/simple-todos/11-testing.md
@@ -82,9 +82,9 @@ if (Meteor.isServer) {
       const userId = Random.id();
       let taskId;
 
-      beforeEach(() => {
-        TasksCollection.remove({});
-        taskId = TasksCollection.insert({
+      beforeEach(async () => {
+        await TasksCollection.removeAsync({});
+        taskId = await TasksCollection.insertAsync({
           text: 'Test Task',
           createdAt: new Date(),
           userId,
@@ -130,10 +130,10 @@ if (Meteor.isServer) {
         });
       });
 
-      it('can delete owned task', () => {
+      it('can delete owned task', async () => {
         mockMethodCall('tasks.remove', taskId, { context: { userId } });
 
-        assert.equal(TasksCollection.find().count(), 0);
+        assert.equal(await TasksCollection.find().countAsync(), 0);
       });
     });
   });
@@ -162,53 +162,53 @@ if (Meteor.isServer) {
       const userId = Random.id();
       let taskId;
 
-      beforeEach(() => {
-        TasksCollection.remove({});
-        taskId = TasksCollection.insert({
+      beforeEach(async () => {
+        await TasksCollection.removeAsync({});
+        taskId = await TasksCollection.insertAsync({
           text: 'Test Task',
           createdAt: new Date(),
           userId,
         });
       });
 
-      it('can delete owned task', () => {
+      it('can delete owned task', async () => {
         mockMethodCall('tasks.remove', taskId, { context: { userId } });
 
-        assert.equal(TasksCollection.find().count(), 0);
+        assert.equal(await TasksCollection.find().countAsync(), 0);
       });
 
-      it(`can't delete task without an user authenticated`, () => {
+      it("can't delete task without an user authenticated", async () => {
         const fn = () => mockMethodCall('tasks.remove', taskId);
         assert.throw(fn, /Not authorized/);
-        assert.equal(TasksCollection.find().count(), 1);
+        assert.equal(await TasksCollection.find().countAsync(), 1);
       });
 
-      it(`can't delete task from another owner`, () => {
+      it("can't delete task from another owner", async () => {
         const fn = () =>
           mockMethodCall('tasks.remove', taskId, {
             context: { userId: 'somebody-else-id' },
           });
         assert.throw(fn, /Access denied/);
-        assert.equal(TasksCollection.find().count(), 1);
+        assert.equal(await TasksCollection.find().countAsync(), 1);
       });
 
-      it('can change the status of a task', () => {
-        const originalTask = TasksCollection.findOne(taskId);
+      it('can change the status of a task', async () => {
+        const originalTask = await TasksCollection.findOneAsync(taskId);
         mockMethodCall('tasks.setIsChecked', taskId, !originalTask.isChecked, {
           context: { userId },
         });
 
-        const updatedTask = TasksCollection.findOne(taskId);
+        const updatedTask = await TasksCollection.findOneAsync(taskId);
         assert.notEqual(updatedTask.isChecked, originalTask.isChecked);
       });
 
-      it('can insert new tasks', () => {
+      it('can insert new tasks', async () => {
         const text = 'New Task';
         mockMethodCall('tasks.insert', text, {
           context: { userId },
         });
 
-        const tasks = TasksCollection.find({}).fetch();
+        const tasks =   await TasksCollection.find({}).fetchAsync();
         assert.equal(tasks.length, 2);
         assert.isTrue(tasks.some(task => task.text === text));
       });


### PR DESCRIPTION
This PR is about updating the tutorial to start using the mongo API introduced in Meteor 2.8

@StorytellerCZ and @jankapunkt, do you guys have any good examples of using promises? I thought of something like with Tracker.autorun, as seen in this forum [post](https://forums.meteor.com/t/async-helper-functions-returning-to-blaze/47228), but I lack some context of Blaze.

Here is a sample of what I did before realizing that it does not accept promises as return value:

```js
// with new Mongo Async API 
async tasks() {
    const instance = Template.instance();
    const hideCompleted = instance.state.get(HIDE_COMPLETED_STRING);

    const { pendingOnlyFilter, userFilter } = getTasksFilter();

    if (!isUserLogged()) {
      return [];
    }

    return await TasksCollection.find(
      hideCompleted ? pendingOnlyFilter : userFilter,
      {
        sort: { createdAt: -1 },
      }
    ).fetchAsync();
  }

// Old one

tasks() {
    const instance = Template.instance();
    const hideCompleted = instance.state.get(HIDE_COMPLETED_STRING);

    const { pendingOnlyFilter, userFilter } = getTasksFilter();

    if (!isUserLogged()) {
      return [];
    }

    return TasksCollection.find(
      hideCompleted ? pendingOnlyFilter : userFilter,
      {
        sort: { createdAt: -1 },
      }
    ).fetch();
  }
```